### PR TITLE
Add support for configuration directory and dynamic script loading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+dirs = "5.0.1"
 evdev-rs = "0.3.1"
 input = "0.9.0"
 libc = "0.2.155"

--- a/README.md
+++ b/README.md
@@ -13,17 +13,24 @@ While wbindkeys intends to replace xbindkeys, in the spirit of wayland being a r
 wbindkeys uses lua for maximum configurability, because sometimes you need an if statement in your config.
 
 ### Config Example
+
+Save the following config in a file named `init.lua` inside your configuration directory (typically found using the `$XDG_CONFIG_HOME` environment variable or defaulting to `~/.config/wbindkeys/`).
+
 ```lua
 -- Run alacritty on ALT+T
 bind("ALT+A", "alacritty")
 bind("ALT+T", "flatpak run org.telegram.desktop")
 ```
 
+### Loading the Configuration
+
+The config file is automatically loaded from the `config_dir()/wbindkeys/init.lua`. Make sure the configuration file exists, otherwise the application will panic.
+
 # Roadmap to 0.1.0
 - [x] Hook into wayland keyboard events
 - [x] Get a binding to execute a print from a lua binding config
 - [x] Execute the command 
-- [x] Fix for launching app in userspace on the users privelege level
+- [x] Fix for launching app in userspace on the users privilege level
 - [ ] Implement and test full range of keymaps
 - [ ] Debian installer
 


### PR DESCRIPTION
- Updated `Cargo.toml` to include `dirs` crate version 5.0.1 for managing paths to configuration directories.
- Expanded README.md with detailed instructions on how to place and use configuration files in the typical configuration directory (`$XDG_CONFIG_HOME` or `~/.config/wbindkeys/`).
- Modified `src/main.rs` to load configuration scripts (`init.lua`) dynamically from the configuration directory.
  - The application now uses the `dirs` crate to determine the location of the configuration directory.
  - Added error handling to ensure the configuration file exists before attempting to load it.
  - Replaced hardcoded script loading with dynamic script loading from the determined configuration path.