### PR TITLE
update makefile and scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,32 @@
 # Rust project makefile
 BIN='wbindkeys'
 
-.Phony : build clean run
+.Phony : build-debug build-release install clean run builddep
 
-build: src/main.rs
+all: build-release
+
+builddep:
+	sudo apt install -y \
+     cargo \
+     libevdev-dev \
+     libudev-dev \
+     libinput-dev \
+
+
+build-debug: src/main.rs
 	cargo build
 
-clean: 
+build-release: src/main.rs
+	cargo build --release
+
+clean:
 	cargo clean
 
-check: 
+check:
 	cargo check
 
-run: build
-	sudo ./target/debug/$(BIN)
+run: build-debug
+	./target/debug/$(BIN)
 
+install: build-release
+	cp target/release/$(BIN) ~/.local/bin/

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ wbindkeys uses lua for maximum configurability, because sometimes you need an if
 Currently the only way to install wbindkeys is to build from source. You will have to build the binary and copy it to a bin directory of your choice.
 
 ```sh
-./configure
-make
-cp target/release/wbindkeys ~/.local/bin
+make builddep
+make release
+make install
 ```
 
 You will then need to run both files in the scripts directory. 
@@ -55,6 +55,6 @@ The config file is automatically loaded from the `config_dir()/wbindkeys/init.lu
 ## Development Setup 
 
 ```sh
-./configure
+make builddep
 make
 ```

--- a/configure
+++ b/configure
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# Install rust if not present 
-if ! command_exists rustc; then
-	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-fi
-sudo apt install -y libevdev-dev
-sudo apt install -y libudev-dev
-sudo apt install -y libinput-dev

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,27 +1,30 @@
 #!/bin/bash
+
+BIN_DEST="${HOME}/.local/bin/wbindkeys"
+SERVICE_DEST="${HOME}/.config/systemd/user/wbindkeys.service"
+
 # Install the wbindkeys binary
 # Assuming wbindkeys is already built and located in the current directory
-cp target/release/wbindkeys /usr/local/bin/
-chmod +x /usr/local/bin/wbindkeys
-echo "Installed wbindkeys to /usr/local/bin."
+mkdir -p $(dirname $BIN_DEST)
+cp target/release/wbindkeys "$BIN_DEST"
+chmod +x "$BIN_DEST"
+echo "Installed wbindkeys to $BIN_DEST"
 
 # Create a systemd service
-SYSTEMD_SERVICE='/etc/systemd/system/wbindkeys.service'
-cat <<EOL > $SYSTEMD_SERVICE
+mkdir -p "$(dirname $SERVICE_DEST)"
+cat <<EOL > $SERVICE_DEST
 [Unit]
 Description=wbindkeys service
 
 [Service]
-ExecStart=/usr/local/bin/wbindkeys
-User=$CURRENT_USER
+Type=simple
+ExecStart=$BIN_DEST
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 EOL
 
-systemctl daemon-reload
-systemctl enable wbindkeys
-systemctl start wbindkeys
+systemctl --user daemon-reload
+systemctl --user enable wbindkeys
+systemctl --user start wbindkeys
 echo "Created and started systemd service."
-
-echo "Installation completed. Please log out and log back in for changes to take effect."

--- a/scripts/permissions.sh
+++ b/scripts/permissions.sh
@@ -11,14 +11,8 @@ if [[ $EUID -ne 0 ]]; then
     exit 1
 fi
 
-# Add the current user to the input group
-CURRENT_USER=$(logname)
-usermod -aG input "$CURRENT_USER"
-echo "Added $CURRENT_USER to the input group."
-
 # Create a udev rule for input devices
-UDEV_RULE='/etc/udev/rules.d/99-input.rules'
-echo 'ACTION=="add", KERNEL=="event*", SUBSYSTEM=="input", MODE="660", GROUP="input"' > "$UDEV_RULE"
+UDEV_RULE='/etc/udev/rules.d/69-wbindkeys.rules'
+echo 'ACTION=="add", KERNEL=="event*", SUBSYSTEM=="input", TAG+="uaccess", TAG+="seat"' > "$UDEV_RULE"
 udevadm control --reload-rules && udevadm trigger
 echo "Created udev rule at $UDEV_RULE."
-


### PR DESCRIPTION
improving(?) the Makefile and scripts a little

The changes are documented in each commit:
 [bc31d55](https://github.com/divanvisagie/wbindkeys/pull/12/commits/bc31d5552e7f5581fdf0c25643dd2c27c8a410f6) Makefile: extend makefile
Extend the makefile:
- to build releases as well
- moving the 'configure' script in, as new target "builddep"
- add an 'install' target

[7fcdd9e](https://github.com/divanvisagie/wbindkeys/pull/12/commits/7fcdd9efef9c85dca8dbca41848cc5b65bce9bbf) scripts: reduce 'permissions' to adding TAG='uaccess,seat'
under systemd+udev its common to just tag input devices for the wayland 'seat' (which runs under the current user). with that in place /dev/input/event* nodes get additional acls that add rw to the user logged in on the wayland seat (hint: check getfacl /dev/input/eventX)

[b3dcb5b](https://github.com/divanvisagie/wbindkeys/pull/12/commits/b3dcb5b0e112cbcafe39153e443f03067a6fbf4e) scripts: install: create user-unit
instead of installing wbindkeys as a system-wide service, create a user-unit instead