### PR TITLE
convert mouse buttons to keyevents

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use dirs::config_dir;
 use input::event::keyboard::{KeyState, KeyboardEventTrait};
-use input::event::pointer::PointerScrollEvent;
+use input::event::pointer::{ButtonState, PointerScrollEvent};
 use input::event::PointerEvent;
 use input::{Event, Libinput, LibinputInterface};
 use libc::{O_RDONLY, O_RDWR, O_WRONLY};
@@ -35,6 +35,13 @@ impl LibinputInterface for WBindKeysInterface {
     }
 }
 
+fn convert_button_to_key_state(button_state: ButtonState) -> KeyState {
+    match button_state {
+        ButtonState::Pressed => KeyState::Pressed,
+        ButtonState::Released => KeyState::Released,
+    }
+}
+
 fn main() {
     let mut input = Libinput::new_with_udev(WBindKeysInterface);
     input.udev_assign_seat("seat0").unwrap();
@@ -65,6 +72,7 @@ fn main() {
                 Event::Pointer(PointerEvent::Motion(_)) => {} // If event is mouse movement do nothing
                 Event::Pointer(PointerEvent::Button(mouse_button)) => {
                     key = mouse_button.button();
+                    state = convert_button_to_key_state(mouse_button.button_state());
                 }
                 Event::Pointer(PointerEvent::ScrollWheel(scroll_event)) => {
                     if scroll_event.has_axis(input::event::pointer::Axis::Vertical) == true {

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,9 +55,10 @@ fn main() {
     script_manager.load_script(&script).unwrap();
 
     let mut active_keys = Vec::new();
-    let mut key:u32 = 0;
-    let mut state: KeyState = KeyState::Released;
     loop {
+        let mut key:u32 = 0;
+        let mut state: KeyState = KeyState::Released;
+
         input.dispatch().unwrap();
         for event in &mut input {
             match event {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -86,6 +86,11 @@ pub enum Keys {
     Mouse3 = 0x112,
     Mouse4 = 0x113,
     Mouse5 = 0x114,
+    Mouse6 = 0x115,
+    Mouse7 = 0x116,
+    Mouse8 = 0x117,
+    Mouse9 = 0x118,
+    Mouse10 = 0x119,
     ScrollLeft = 0x996,
     ScrollRight = 0x997,
     ScrollUp = 0x998,
@@ -186,11 +191,16 @@ pub fn parse_binding(binding: &str) -> Vec<u32> {
             "Mouse2"=> keys.push(Keys::Mouse2 as u32),
             "Mouse3"=> keys.push(Keys::Mouse3 as u32),
             "Mouse4"=> keys.push(Keys::Mouse4 as u32),
-            "Mouse5"=> keys.push(Keys::Mouse5 as u32),            
-            "ScrollLeft"=> keys.push(Keys::ScrollLeft as u32),            
-            "ScrollRight"=> keys.push(Keys::ScrollRight as u32),            
-            "ScrollUp"=> keys.push(Keys::ScrollUp as u32),            
-            "ScrollDown"=> keys.push(Keys::ScrollDown as u32),            
+            "Mouse5"=> keys.push(Keys::Mouse5 as u32),
+            "Mouse6"=> keys.push(Keys::Mouse6 as u32),
+            "Mouse7"=> keys.push(Keys::Mouse7 as u32),
+            "Mouse8"=> keys.push(Keys::Mouse8 as u32),
+            "Mouse9"=> keys.push(Keys::Mouse9 as u32),
+            "Mouse10"=> keys.push(Keys::Mouse10 as u32),
+            "ScrollLeft"=> keys.push(Keys::ScrollLeft as u32),
+            "ScrollRight"=> keys.push(Keys::ScrollRight as u32),
+            "ScrollUp"=> keys.push(Keys::ScrollUp as u32),
+            "ScrollDown"=> keys.push(Keys::ScrollDown as u32),
             _ => {}
         }
     }
@@ -287,7 +297,6 @@ mod tests {
             ("F11", Keys::F11 as u32),
             ("F12", Keys::F12 as u32),
             ("F12", Keys::F12 as u32),
-  
         ];
 
         for (input, expected_output) in test_cases {


### PR DESCRIPTION
the first two commits from #11 - put on the fast lane(?)

To be able to bind to mouse button events, they need to be converted to key events.
This PR 
- refactors the loop a bit, moving variable assignment in
- adds all possible mousebuttons that are declared in the usb descriptor - so that now up to ten button mice are supported.
- adds a helper to convert event types
- convert events inside the loop so that they are available as mapping targets in the config